### PR TITLE
Update readme to match repo and package name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
-process-nexttick-args
+process-nextick-args
 =====
 
 [![Build Status](https://travis-ci.org/calvinmetcalf/process-nextick-args.svg?branch=master)](https://travis-ci.org/calvinmetcalf/process-nextick-args)
 
 ```bash
-npm install --save process-nexttick-args
+npm install --save process-nextick-args
 ```
 
 Always be able to pass arguments to process.nextTick, no matter the platform
 
 ```js
-var nextTick = require('process-nexttick-args');
+var nextTick = require('process-nextick-args');
 
 nextTick(function (a, b, c) {
   console.log(a, b, c);


### PR DESCRIPTION
Not sure if you meant for the repo and package to have only one `t`, but since that is how things are I'm sending this to correct the readme to match. Another solution is rename the package and repo but that'll affect folks who depend on this.
