### PR TITLE
Prevent deoptimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = nextTick;
 function nextTick(fn) {
   var args = new Array(arguments.length - 1);
   var i = 0;
-  while (i < arguments.length) {
+  while (i < args.length) {
     args[i++] = arguments[i];
   }
   process.nextTick(function afterTick() {


### PR DESCRIPTION
This prevents de-optimization due to out-of-bounds access on `arguments`.
It also prevents a stray `undefined` argument to be passed down to the `fn` callback function.
