### PR TITLE
Use the native process.nextTick when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
-module.exports = nextTick;
+
+if (process.version.indexOf('v0.1') === 0) {
+  module.exports = nextTick;
+} else {
+  module.exports = process.nextTick;
+}
 
 function nextTick(fn) {
   var args = new Array(arguments.length - 1);

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-if (process.version.indexOf('v0.1') === 0) {
-  module.exports = nextTick;
-} else {
+if (process.version && parseInt(process.version.split('.')[0].slice(1), 10) > 0) {
   module.exports = process.nextTick;
+} else {
+  module.exports = nextTick;
 }
 
 function nextTick(fn) {


### PR DESCRIPTION
The wrapper that is used it's causing a lot of functions to be allocated when using the readable-stream module. This would be ~10% faster on node 4+, while maintaining backward compatibility.
