### PR TITLE
Don't use process.nextTick on io.js versions older than v1.8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
-if (process.version && parseInt(process.version.split('.')[0].slice(1), 10) > 0) {
-  module.exports = process.nextTick;
-} else {
+if (!process.version ||
+    process.version.indexOf('v0.') === 0 ||
+    process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
   module.exports = nextTick;
+} else {
+  module.exports = process.nextTick;
 }
 
 function nextTick(fn) {


### PR DESCRIPTION
v1.8.x is the only io.js version in the v1.x series that supports arguments for `process.nextTick()`.
