### PR TITLE
Fix bug with process.nextTick referencing the wrong function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 if (!process.version ||
     process.version.indexOf('v0.') === 0 ||
     process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
-  module.exports = nextTickPolyfill;
+  module.exports = { nextTick: nextTick };
 } else {
-  module.exports = nextTickWrapper;
+  module.exports = process
 }
 
-function nextTickPolyfill(fn, arg1, arg2, arg3) {
+function nextTick(fn, arg1, arg2, arg3) {
   if (typeof fn !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -42,18 +42,3 @@ function nextTickPolyfill(fn, arg1, arg2, arg3) {
   }
 }
 
-function nextTickWrapper(fn, arg1, arg2, arg3) {
-  switch (arguments.length) {
-  case 0:
-  case 1:
-    return process.nextTick(fn);
-  case 2:
-    return process.nextTick(fn, arg1);
-  case 3:
-    return process.nextTick(fn, arg1, arg2);
-  case 4:
-    return process.nextTick(fn, arg1, arg2, arg3);
-  default:
-    return process.nextTick.apply(process, arguments);
-  }
-}

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var usePolyfill = !process.version ||
+if (!process.version ||
     process.version.indexOf('v0.') === 0 ||
-    process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0;
+    process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
+  module.exports = nextTickPolyfill;
+} else {
+  module.exports = nextTickWrapper;
+}
 
-module.exports = nextTick;
-
-function nextTick(fn, arg1, arg2, arg3) {
+function nextTickPolyfill(fn, arg1, arg2, arg3) {
   if (typeof fn !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -17,27 +19,18 @@ function nextTick(fn, arg1, arg2, arg3) {
   case 1:
     return process.nextTick(fn);
   case 2:
-    return usePolyfill ?
-      process.nextTick(function afterTickOne() {
-        fn.call(null, arg1);
-      }) :
-      process.nextTick(fn, arg1);
+    return process.nextTick(function afterTickOne() {
+      fn.call(null, arg1);
+    });
   case 3:
-    return usePolyfill ?
-      process.nextTick(function afterTickTwo() {
-        fn.call(null, arg1, arg2);
-      }) :
-      process.nextTick(fn, arg1, arg2);
+    return process.nextTick(function afterTickTwo() {
+      fn.call(null, arg1, arg2);
+    });
   case 4:
-    return usePolyfill ?
-      process.nextTick(function afterTickThree() {
-        fn.call(null, arg1, arg2, arg3);
-      }) :
-      process.nextTick(fn, arg1, arg2, arg3);
+    return process.nextTick(function afterTickThree() {
+      fn.call(null, arg1, arg2, arg3);
+    });
   default:
-    if (!usePolyfill) {
-      return process.nextTick.apply(null, arguments);
-    }
     args = new Array(len - 1);
     i = 0;
     while (i < args.length) {
@@ -46,5 +39,21 @@ function nextTick(fn, arg1, arg2, arg3) {
     return process.nextTick(function afterTick() {
       fn.apply(null, args);
     });
+  }
+}
+
+function nextTickWrapper(fn, arg1, arg2, arg3) {
+  switch (arguments.length) {
+  case 0:
+  case 1:
+    return process.nextTick(fn);
+  case 2:
+    return process.nextTick(fn, arg1);
+  case 3:
+    return process.nextTick(fn, arg1, arg2);
+  case 4:
+    return process.nextTick(fn, arg1, arg2, arg3);
+  default:
+    return process.nextTick.apply(process, arguments);
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 'use strict';
 
-if (!process.version ||
+var usePolyfill = !process.version ||
     process.version.indexOf('v0.') === 0 ||
-    process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
-  module.exports = nextTick;
-} else {
-  module.exports = process.nextTick;
-}
+    process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0;
+
+module.exports = nextTick;
 
 function nextTick(fn, arg1, arg2, arg3) {
   if (typeof fn !== 'function') {
@@ -19,18 +17,27 @@ function nextTick(fn, arg1, arg2, arg3) {
   case 1:
     return process.nextTick(fn);
   case 2:
-    return process.nextTick(function afterTickOne() {
-      fn.call(null, arg1);
-    });
+    return usePolyfill ?
+      process.nextTick(function afterTickOne() {
+        fn.call(null, arg1);
+      }) :
+      process.nextTick(fn, arg1);
   case 3:
-    return process.nextTick(function afterTickTwo() {
-      fn.call(null, arg1, arg2);
-    });
+    return usePolyfill ?
+      process.nextTick(function afterTickTwo() {
+        fn.call(null, arg1, arg2);
+      }) :
+      process.nextTick(fn, arg1, arg2);
   case 4:
-    return process.nextTick(function afterTickThree() {
-      fn.call(null, arg1, arg2, arg3);
-    });
+    return usePolyfill ?
+      process.nextTick(function afterTickThree() {
+        fn.call(null, arg1, arg2, arg3);
+      }) :
+      process.nextTick(fn, arg1, arg2, arg3);
   default:
+    if (!usePolyfill) {
+      return process.nextTick.apply(null, arguments);
+    }
     args = new Array(len - 1);
     i = 0;
     while (i < args.length) {

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,9 @@ npm install --save process-nextick-args
 Always be able to pass arguments to process.nextTick, no matter the platform
 
 ```js
-var nextTick = require('process-nextick-args');
+var pna = require('process-nextick-args');
 
-nextTick(function (a, b, c) {
+pna.nextTick(function (a, b, c) {
   console.log(a, b, c);
 }, 'step', 3,  'profit');
 ```

--- a/test.js
+++ b/test.js
@@ -22,3 +22,15 @@ test('correct number of arguments', function (t) {
     t.equals(2, arguments.length, 'correct number');
   }, 1, 2);
 });
+
+test('uses the current value of process.nextTick', function (t) {
+  t.plan(1);
+  var oldNextTick = process.nextTick;
+  var called = false;
+  process.nextTick = function() {
+    called = true
+  };
+  nextTick(function () {});
+  process.nextTick = oldNextTick;
+  t.ok(called);
+});

--- a/test.js
+++ b/test.js
@@ -1,15 +1,15 @@
 var test = require("tap").test;
-var nextTick = require('./');
+var pna = require('./');
 
 test('should work', function (t) {
   t.plan(5);
-  nextTick(function (a) {
+  pna.nextTick(function (a) {
     t.ok(a);
-    nextTick(function (thing) {
+    pna.nextTick(function (thing) {
       t.equals(thing, 7);
     }, 7);
   }, true);
-  nextTick(function (a, b, c) {
+  pna.nextTick(function (a, b, c) {
     t.equals(a, 'step');
     t.equals(b, 3);
     t.equals(c, 'profit');
@@ -18,7 +18,7 @@ test('should work', function (t) {
 
 test('correct number of arguments', function (t) {
   t.plan(1);
-  nextTick(function () {
+  pna.nextTick(function () {
     t.equals(2, arguments.length, 'correct number');
   }, 1, 2);
 });
@@ -30,7 +30,7 @@ test('uses the current value of process.nextTick', function (t) {
   process.nextTick = function() {
     called = true
   };
-  nextTick(function () {});
+  pna.nextTick(function () {});
   process.nextTick = oldNextTick;
   t.ok(called);
 });


### PR DESCRIPTION
`lolex` and by extension `sinon` fake timers, change the value of
`process.nextTick` in order to properly be added to the fake event loop stack.
The previous way this module was written kept a reference to the original
function and didn't look up the current value of `process.nextTick`. This
commit makes each invocation of nextTick look up the current value of
`process.nextTick`.

I verified that the tests still pass on `v0.12` as well as `v8.x`

You can run this test to see the bug and the fix in action:

```js
var lolex = require('lolex');
var through = require('through2');

describe('a bug', function() {
  var clock;
  before(function() {
    clock = lolex.install({toFake: [ 'setImmediate', 'nextTick' ]});
  });
  after(function() {
    clock.uninstall();
  });

  it('does not work well with lolex', function(done) {
    var stream = through.obj();
    stream.on('data', function() {
      stream.on('end', function() {

        console.log('creating stream2')
        var stream2 = through.obj();
        stream2.on('data', function() {
          stream2.on('end', function() {
            console.log('OK')
            done();            
          });
          setImmediate(function() {
            stream2.end()
          });
        });
        stream2.emit('data')

      });
      stream.end();
    });
    stream.emit('data');

    clock.runAll()
  });

});
```

Before the change it would just hang after logging `creating stream2`. After this change it works as expected.